### PR TITLE
add mem map for reading and writing bigger graphs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Node2Vec 
+# Node2Vec
 [![Downloads](http://pepy.tech/badge/node2vec)](http://pepy.tech/project/node2vec)
 
 Python3 implementation of the node2vec algorithm Aditya Grover, Jure Leskovec and Vid Kocijan.
@@ -24,7 +24,7 @@ from node2vec import Node2Vec
 graph = nx.fast_gnp_random_graph(n=100, p=0.5)
 
 # Precompute probabilities and generate walks - **ON WINDOWS ONLY WORKS WITH workers=1**
-node2vec = Node2Vec(graph, dimensions=64, walk_length=30, num_walks=200, workers=4) 
+node2vec = Node2Vec(graph, dimensions=64, walk_length=30, num_walks=200, workers=4)  # pass temp_folder for the big graphs
 
 # Embed nodes
 model = node2vec.fit(window=10, min_count=1, batch_words=4)  # Any keywords acceptable by gensim.Word2Vec can be passed, `diemnsions` and `workers` are automatically passed (from the Node2Vec constructor)
@@ -79,7 +79,7 @@ edges_kv.save_word2vec_format(EDGES_EMBEDDING_FILENAME)
     9. `sampling_strategy`: Node specific sampling strategies, supports setting node specific 'q', 'p', 'num_walks' and 'walk_length'.
         Use these keys exactly. If not set, will use the global ones which were passed on the object initialization`
     10. `quiet`: Boolean controlling the verbosity. (default: False)
-    
+
 - `Node2Vec.fit` method:
     Accepts any key word argument acceptable by gensim.Word2Vec
 

--- a/example.py
+++ b/example.py
@@ -10,8 +10,10 @@ graph = nx.fast_gnp_random_graph(n=100, p=0.5)
 
 # Precompute probabilities and generate walks
 node2vec = Node2Vec(graph, dimensions=64, walk_length=30, num_walks=200, workers=4)
-## if d_graph is big enough to fit in the memory, pass tmp_dir which has enough disk space
-node2vec = Node2Vec(graph, dimensions=64, walk_length=30, num_walks=200, workers=4, tmp_dir="/mnt/tmp_data")
+
+## if d_graph is big enough to fit in the memory, pass temp_folder which has enough disk space
+# Note: It will trigger "sharedmem" in Parallel, which will be slow on smaller graphs
+#node2vec = Node2Vec(graph, dimensions=64, walk_length=30, num_walks=200, workers=4, temp_folder="/mnt/tmp_data")
 
 # Embed
 model = node2vec.fit(window=10, min_count=1, batch_words=4)  # Any keywords acceptable by gensim.Word2Vec can be passed, `diemnsions` and `workers` are automatically passed (from the Node2Vec constructor)

--- a/example.py
+++ b/example.py
@@ -10,6 +10,8 @@ graph = nx.fast_gnp_random_graph(n=100, p=0.5)
 
 # Precompute probabilities and generate walks
 node2vec = Node2Vec(graph, dimensions=64, walk_length=30, num_walks=200, workers=4)
+## if d_graph is big enough to fit in the memory, pass tmp_dir which has enough disk space
+node2vec = Node2Vec(graph, dimensions=64, walk_length=30, num_walks=200, workers=4, tmp_dir="/mnt/tmp_data")
 
 # Embed
 model = node2vec.fit(window=10, min_count=1, batch_words=4)  # Any keywords acceptable by gensim.Word2Vec can be passed, `diemnsions` and `workers` are automatically passed (from the Node2Vec constructor)

--- a/node2vec/node2vec.py
+++ b/node2vec/node2vec.py
@@ -1,10 +1,10 @@
+
 from collections import defaultdict
 import numpy as np
 import gensim, os
 from joblib import Parallel, delayed, load, dump
 from tqdm import tqdm
-# from .parallel import parallel_generate_walks
-from parallel import parallel_generate_walks
+from .parallel import parallel_generate_walks
 
 
 class Node2Vec:


### PR DESCRIPTION
This is in response to the existing issue [here](https://github.com/eliorc/node2vec/issues/8#issue-369319541).

The new branch contains code to create a temporary folder to hold a memory map of self.d_graph.
This is based on the discussion on this [joblib's page](https://joblib.readthedocs.io/en/latest/parallel.html#manual-management-of-memmaped-input-data).

This memory map is deleted using the __del__ destructor inside the Node2Vec class. This is done as per the discussion [here.](https://joblib.readthedocs.io/en/latest/parallel.html#writing-parallel-computation-results-in-shared-memory)