### PR TITLE
Add seed parameter.

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ edges_kv.save_word2vec_format(EDGES_EMBEDDING_FILENAME)
         Use these keys exactly. If not set, will use the global ones which were passed on the object initialization`
     10. `quiet`: Boolean controlling the verbosity. (default: False)
     11. `temp_folder`: String path pointing to folder to save a shared memory copy of the graph - Supply when working on graphs that are too big to fit in memory during algorithm execution.
-    12. `seed`: Seed for the random number generator.
+    12. `seed`: Seed for the random number generator (default: None). Deterministic results can be obtained if seed is set and `workers=1`.
 
 - `Node2Vec.fit` method:
     Accepts any key word argument acceptable by gensim.Word2Vec

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ graph = nx.fast_gnp_random_graph(n=100, p=0.5)
 node2vec = Node2Vec(graph, dimensions=64, walk_length=30, num_walks=200, workers=4)  # Use temp_folder for big graphs
 
 # Embed nodes
-model = node2vec.fit(window=10, min_count=1, batch_words=4)  # Any keywords acceptable by gensim.Word2Vec can be passed, `diemnsions` and `workers` are automatically passed (from the Node2Vec constructor)
+model = node2vec.fit(window=10, min_count=1, batch_words=4)  # Any keywords acceptable by gensim.Word2Vec can be passed, `dimensions` and `workers` are automatically passed (from the Node2Vec constructor)
 
 # Look for most similar nodes
 model.wv.most_similar('2')  # Output node names are always strings

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ edges_kv.save_word2vec_format(EDGES_EMBEDDING_FILENAME)
         Use these keys exactly. If not set, will use the global ones which were passed on the object initialization`
     10. `quiet`: Boolean controlling the verbosity. (default: False)
     11. `temp_folder`: String path pointing to folder to save a shared memory copy of the graph - Supply when working on graphs that are too big to fit in memory during algorithm execution.
+    12. `seed`: Seed for the random number generator.
 
 - `Node2Vec.fit` method:
     Accepts any key word argument acceptable by gensim.Word2Vec

--- a/node2vec/node2vec.py
+++ b/node2vec/node2vec.py
@@ -1,3 +1,4 @@
+import random
 import os
 from collections import defaultdict
 
@@ -22,7 +23,7 @@ class Node2Vec:
 
     def __init__(self, graph: nx.Graph, dimensions: int = 128, walk_length: int = 80, num_walks: int = 10, p: float = 1,
                  q: float = 1, weight_key: str = 'weight', workers: int = 1, sampling_strategy: dict = None,
-                 quiet: bool = False, temp_folder: str = None):
+                 quiet: bool = False, temp_folder: str = None, seed: int = None):
         """
         Initiates the Node2Vec object, precomputes walking probabilities and generates the walks.
 
@@ -35,6 +36,7 @@ class Node2Vec:
         :param weight_key: On weighted graphs, this is the key for the weight attribute (default: 'weight')
         :param workers: Number of workers for parallel execution (default: 1)
         :param sampling_strategy: Node specific sampling strategies, supports setting node specific 'q', 'p', 'num_walks' and 'walk_length'.
+        :param seed: Seed for the random number generator.
         Use these keys exactly. If not set, will use the global ones which were passed on the object initialization
         :param temp_folder: Path to folder with enough space to hold the memory map of self.d_graph (for big graphs); to be passed joblib.Parallel.temp_folder
         """
@@ -62,6 +64,10 @@ class Node2Vec:
 
             self.temp_folder = temp_folder
             self.require = "sharedmem"
+
+        if seed is not None:
+            random.seed(seed)
+            np.random.seed(seed)
 
         self._precompute_probabilities()
         self.walks = self._generate_walks()


### PR DESCRIPTION
Hi Elior Cohen (and others),

This is my first pull request ever. Please help me a bit when I miss certain things.

A while ago we noticed that this Node2Vec implementation yields different results, even when run in one Python process. This problem is also mentioned by @marcovarrone in Issue #26.

In this pull request, we (@pereirabarataap and me) propose to add a simple parameter `seed`, which allows to set the random seed of both Numpy and the Python random module.

This issue fixes:
- [x] When calling Node2Vec with the same parameters, will obtain the exact same embedding in one process. We show this in the `another-example.py` at https://github.com/gerritjandebruin/node2vec/blob/another-example/another-example.py.

Future work:
- [ ] Make the seed also work with multiple workers.
- [ ] Make the seed work between different Python process. 
      At this moment it does not, also not with a fixed PYTHONHASHSEED.

Kind regards,

Gerrit-Jan and António
