### PR TITLE
Update node2vec.py

### DIFF
--- a/node2vec/node2vec.py
+++ b/node2vec/node2vec.py
@@ -175,7 +175,7 @@ class Node2Vec:
             skip_gram_params['workers'] = self.workers
 
         if 'size' not in skip_gram_params:
-            skip_gram_params['size'] = self.dimensions
+            skip_gram_params['vector_size'] = self.dimensions
 
         if 'sg' not in skip_gram_params:
             skip_gram_params['sg'] = 1

--- a/node2vec/node2vec.py
+++ b/node2vec/node2vec.py
@@ -174,7 +174,7 @@ class Node2Vec:
         if 'workers' not in skip_gram_params:
             skip_gram_params['workers'] = self.workers
 
-        if 'size' not in skip_gram_params:
+        if 'vector_size' not in skip_gram_params:
             skip_gram_params['vector_size'] = self.dimensions
 
         if 'sg' not in skip_gram_params:


### PR DESCRIPTION
The newest genism model updated one of the parameters' names from "size" to "vector_size". This has been preventing me from running the model. 
I got error message as the following:
node2vec __init__() got an unexpected keyword argument 'size'