### PR TITLE
Remove dependency of deprecated package pkg_resources

### DIFF
--- a/node2vec/check_gensim.py
+++ b/node2vec/check_gensim.py
@@ -1,0 +1,4 @@
+from importlib.metadata import version
+
+def is_dated_gensim_version():
+    return version("gensim") < '4.0.0'

--- a/node2vec/edges.py
+++ b/node2vec/edges.py
@@ -3,7 +3,7 @@ from functools import reduce
 from itertools import combinations_with_replacement
 
 import numpy as np
-from check_gensim import is_dated_gensim_version
+from .check_gensim import is_dated_gensim_version
 from gensim.models import KeyedVectors
 from tqdm import tqdm
 

--- a/node2vec/edges.py
+++ b/node2vec/edges.py
@@ -3,13 +3,14 @@ from functools import reduce
 from itertools import combinations_with_replacement
 
 import numpy as np
-import pkg_resources
+from check_gensim import is_dated_gensim_version
 from gensim.models import KeyedVectors
 from tqdm import tqdm
 
 
+
 class EdgeEmbedder(ABC):
-    INDEX_MAPPING_KEY = 'index2word' if pkg_resources.get_distribution("gensim").version < '4.0.0' else 'index_to_key'
+    INDEX_MAPPING_KEY = 'index2word' if is_dated_gensim_version() else 'index_to_key'
 
     def __init__(self, keyed_vectors: KeyedVectors, quiet: bool = False):
         """
@@ -67,7 +68,7 @@ class EdgeEmbedder(ABC):
 
         # Build KV instance
         edge_kv = KeyedVectors(vector_size=self.kv.vector_size)
-        if pkg_resources.get_distribution("gensim").version < '4.0.0':
+        if is_dated_gensim_version():
             edge_kv.add(
                 entities=tokens,
                 weights=features)

--- a/node2vec/node2vec.py
+++ b/node2vec/node2vec.py
@@ -137,11 +137,9 @@ class Node2Vec:
             first_travel_weights = []
 
             for destination in self.graph.neighbors(source):
-                # print(source, destination, self.graph[source][destination]["weight"])
                 first_travel_weights.append(self.graph[source][destination].get(self.weight_key, 1))
 
             first_travel_weights = np.array(first_travel_weights)
-            # print(first_travel_weights)
             d_graph[source][self.FIRST_TRAVEL_KEY] = first_travel_weights / first_travel_weights.sum()
 
             # Save neighbors

--- a/node2vec/node2vec.py
+++ b/node2vec/node2vec.py
@@ -5,7 +5,7 @@ from collections import defaultdict
 import gensim
 import networkx as nx
 import numpy as np
-from check_gensim import is_dated_gensim_version
+from .check_gensim import is_dated_gensim_version
 from joblib import Parallel, delayed
 from tqdm.auto import tqdm
 

--- a/node2vec/node2vec.py
+++ b/node2vec/node2vec.py
@@ -5,7 +5,7 @@ from collections import defaultdict
 import gensim
 import networkx as nx
 import numpy as np
-import pkg_resources
+from check_gensim import is_dated_gensim_version
 from joblib import Parallel, delayed
 from tqdm.auto import tqdm
 
@@ -137,9 +137,11 @@ class Node2Vec:
             first_travel_weights = []
 
             for destination in self.graph.neighbors(source):
+                # print(source, destination, self.graph[source][destination]["weight"])
                 first_travel_weights.append(self.graph[source][destination].get(self.weight_key, 1))
 
             first_travel_weights = np.array(first_travel_weights)
+            # print(first_travel_weights)
             d_graph[source][self.FIRST_TRAVEL_KEY] = first_travel_weights / first_travel_weights.sum()
 
             # Save neighbors
@@ -188,8 +190,7 @@ class Node2Vec:
             skip_gram_params['workers'] = self.workers
 
         # Figure out gensim version, naming of output dimensions changed from size to vector_size in v4.0.0
-        gensim_version = pkg_resources.get_distribution("gensim").version
-        size = 'size' if gensim_version < '4.0.0' else 'vector_size'
+        size = 'size' if is_dated_gensim_version() else 'vector_size'
         if size not in skip_gram_params:
             skip_gram_params[size] = self.dimensions
 


### PR DESCRIPTION
The package ```pkg_resources``` has been deprecated, so node2vec crashes with ```python -W error [...]```. I've implemented the recommended alternative using ```importlib.metadata.version```.

Error message for ```pkg_resources```:
```DeprecationWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html```